### PR TITLE
Don't skip orgs

### DIFF
--- a/migrator.sh
+++ b/migrator.sh
@@ -59,7 +59,6 @@ done
 echo
 echo 'Remove unneeded dumps'
 rm $3/migration_log.dump
-rm $3/org.dump
 rm $3/plugin_setting.dump
 echo 'Replacing ` with "'
 sed -i s/\`/\"/g $3/*.dump;


### PR DESCRIPTION
It looks like you're explicitly removing the org and plugin_setting tables and preventing them from being migrated. Why? The org seems to contain important data in most cases. Removing this rm  should fix https://github.com/haron/grafana-migrator/issues/2. 

I'm imagining some default org stuff might be setup as part of the migrations when grafana starts. If that's the case, it seems that the best solution would be to change the insert for the org item with id 1 to be an update. I can work on that if you agree.